### PR TITLE
modernise Pyterrier usage

### DIFF
--- a/examples/search.ipynb
+++ b/examples/search.ipynb
@@ -2,185 +2,150 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Using Elasticsearch in PyTerrier experiments\n",
     "Elasticsearch can store huge indices that could not easily be retrieved from with PyTerrier.\n",
     "Using the Elasticsearch API via the [`elasticsearch`](https://pypi.org/project/elasticsearch/) Python package,\n",
     "we can integrate large indices into PyTerrier experiments and take advantage of Elasticsearch's distribution capabilities."
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
-  },
-  {
-   "cell_type": "markdown",
+   },
    "source": [
     "## Configuration\n",
     "To access Elasticsearch, we need to connect to a cluster by URL, username, and password. Refer to the [API documentation](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html) about other ways to connect to a cluster."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "url: str = input(\"Elasticsearch URL: \")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "username: str = input(\"Elasticsearch username: \")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "password: str = input(\"Elasticsearch password: \")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "index: str = input(\"Elasticsearch index: \")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Install Python packages if run in Google Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "## Setup"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "Install Python packages if run in Google Colab."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   },
    "outputs": [],
    "source": [
     "from sys import modules\n",
     "\n",
     "if \"google.colab\" in modules:\n",
     "    !pip install -q chatnoir-pyterrier python-terrier"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Initialize PyTerrier."
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from pyterrier import init, started"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "if not started():\n",
-    "    init()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "markdown",
+   },
    "source": [
     "Connect to Elasticsearch cluster."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from elasticsearch import Elasticsearch\n",
@@ -190,16 +155,16 @@
     "    basic_auth=(username, password)\n",
     ")\n",
     "client"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Retrieval pipeline\n",
     "We can now create a retrieval pipeline which retrieves results from Elasticsearch.\n",
@@ -207,25 +172,23 @@
     "You can then use the pipeline in the same way as `BatchRetrieve`.\n",
     "\n",
     "The `fields` parameter specifies on which fields of the Elasticsearch index the terms should match.\n",
-    "The `columns` parameter then specifies which Elasticsearch fields are mapped to which column in the result data frame.\n",
-    "\n",
-    "(We [cache](https://pyterrier.readthedocs.io/en/latest/operators.html#caching) the transformer results with `~`.)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+    "The `columns` parameter then specifies which Elasticsearch fields are mapped to which column in the result data frame."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from pyterrier_elasticsearch import ElasticsearchRetrieve\n",
     "\n",
-    "es_text_title = ~ElasticsearchRetrieve(\n",
+    "es_text_title = ElasticsearchRetrieve(\n",
     "    client=client,\n",
     "    index=index,\n",
     "    fields=[\"text\", \"title\"],\n",
@@ -236,120 +199,120 @@
     "    },\n",
     "    verbose=True,\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Search\n",
-    "For example, we can search the ClueWeb 12 for documents containing `python library`:"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "### Search\n",
+    "For example, we can search the ClueWeb 12 for documents containing `python library`:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "es_text_title.search(\"python library\")"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "es_text_title.search(\"python library\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Evaluation\n",
     "We can also use the pipeline in a PyTerrier `Experiment` (and compare it to other retrieval pipelines).\n",
     "First, we need to download the test topics, for example from the TREC Web Track 2014.\n",
     "(Refer to the [PyTerrier documentation](https://pyterrier.readthedocs.io/en/latest/datasets.html#examples) for more detailed guides.)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from pandas import DataFrame\n",
-    "from pyterrier.datasets import Dataset, get_dataset\n",
+    "from pyterrier import Dataset, get_dataset\n",
     "\n",
     "dataset: Dataset = get_dataset(\"irds:clueweb12/trec-web-2014\")\n",
     "topics: DataFrame = dataset.get_topics(variant=\"query\").iloc[:5]"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Now we can, for example, retrieve documents for the TREC Web Track 2014 topics."
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Now we can, for example, retrieve documents for the TREC Web Track 2014 topics."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "es_text_title.transform(topics)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Alternatively, we could compare the results with searching only the text field."
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Alternatively, we could compare the results with searching only the text field."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from pyterrier_elasticsearch import ElasticsearchRetrieve\n",
     "\n",
-    "es_text = ~ElasticsearchRetrieve(\n",
+    "es_text = ElasticsearchRetrieve(\n",
     "    client=client,\n",
     "    index=index,\n",
     "    fields=[\"text\"],\n",
@@ -360,45 +323,45 @@
     "    },\n",
     "    verbose=True,\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Then we runs an experiment like this"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Then we runs an experiment like this"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from ir_measures import nDCG, RR, MAP\n",
-    "from pyterrier.pipelines import Experiment\n",
+    "from pyterrier import Experiment\n",
     "\n",
     "Experiment(\n",
     "    [es_text_title, es_text],\n",
@@ -407,13 +370,7 @@
     "    eval_metrics=[nDCG @ 5, MAP, RR],\n",
     "    names=[\"ES (text+title)\", \"ES (text)\"],\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {

--- a/pyterrier_elasticsearch/retrieve.py
+++ b/pyterrier_elasticsearch/retrieve.py
@@ -6,7 +6,7 @@ from elasticsearch import Elasticsearch
 from pandas import DataFrame
 from pandas.core.groupby import DataFrameGroupBy
 from pyterrier.model import add_ranks
-from pyterrier.transformer import Transformer
+from pyterrier import Transformer
 from tqdm.auto import tqdm
 
 


### PR DESCRIPTION
Hi @janheinrichmerker 

Just a few changes to modernise the PyTerrier usage:
 - dont need pt.init() any more
 - refer to pt.Experiment, not pt.pipelines.Experiment
 - refer to pt.Transformer
 - remove caching using ~ operator; we're going to deprecate in favour of https://github.com/seanmacavaney/pyterrier-caching